### PR TITLE
Put a character in unclaimed spaces

### DIFF
--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -74,7 +74,7 @@ class Fun(commands.Cog):
           elif options[i][j] == X:
             board[i][j] = Button(style=ButtonStyle.red, label="X", id=f"{i} {j}", disabled=True)
           else:
-            board[i][j] = Button(style=ButtonStyle.grey, label="\u200b", id=f"{i} {j}", disabled=disabled)
+            board[i][j] = Button(style=ButtonStyle.grey, label="-", id=f"{i} {j}", disabled=disabled)
       return board
 
     #check if there is a winner


### PR DESCRIPTION
Makes spacing even for consistency, specifically on mobile, where buttons do not have a uniform width